### PR TITLE
Explicitly uses inline namespace declarations

### DIFF
--- a/demo/Source/MainComponent.h
+++ b/demo/Source/MainComponent.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <JuceHeader.h>
-using namespace juce;
 
 #include "HeadMatrix.h"
 #include "Tracker.h"

--- a/supperware/configpanel/configPanel-BasePanel.h
+++ b/supperware/configpanel/configPanel-BasePanel.h
@@ -10,13 +10,13 @@ namespace ConfigPanel
 {
     enum class LabelStyle { SectionHeading, Description, Data, SubData };
 
-    class BasePanel : public Component, public MultiTimer,
-        private Button::Listener, private ComboBox::Listener
+    class BasePanel : public juce::Component, public juce::MultiTimer,
+        private juce::Button::Listener, private juce::ComboBox::Listener
     {
     public:
         static constexpr int LabelWidth { 256 }; // window width is derived from LabelWidth
 
-        BasePanel(String titleText) :
+        BasePanel(juce::String titleText) :
             Component(),
             labels(), textButtons(), toggleButtons(), comboBoxes(),
             title(titleText), lookAndFeelRadio()
@@ -41,16 +41,16 @@ namespace ConfigPanel
 
         // ---------------------------------------------------------------------
         
-        void buttonClicked(Button* button) override
+        void buttonClicked(juce::Button* button) override
         {
-            TextButton* textB = dynamic_cast<TextButton*>(button);
+            juce::TextButton* textB = dynamic_cast<juce::TextButton*>(button);
             if (textB)
             {
                 click(true, textButtons.indexOf(textB), false);
             }
             else
             {
-                ToggleButton* toggleB = dynamic_cast<ToggleButton*>(button);
+                juce::ToggleButton* toggleB = dynamic_cast<juce::ToggleButton*>(button);
                 if (toggleB)
                 {
                     click(false, toggleButtons.indexOf(toggleB), toggleB->getToggleState());
@@ -60,7 +60,7 @@ namespace ConfigPanel
 
         // ---------------------------------------------------------------------
 
-        void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override
+        void comboBoxChanged(juce::ComboBox* comboBoxThatHasChanged) override
         {
             int cbIndex = comboBoxes.indexOf(comboBoxThatHasChanged);
             comboBox(cbIndex, comboBoxThatHasChanged->getSelectedItemIndex());
@@ -86,30 +86,30 @@ namespace ConfigPanel
             }
         }
 
-        void paint(Graphics& g) override
+        void paint(juce::Graphics& g) override
         {
             if (!title.isEmpty())
             {
                 // draw title
-                g.setColour(Colour(0xff0c0c0c));
+                g.setColour(juce::Colour(0xff0c0c0c));
                 g.fillRect(0, 2, LabelWidth, 21);
                 g.setColour(TitleLabel);
-                g.setFont(Font(16.0, Font::plain));
-                g.drawText(title, 8, 4, 200, 200, Justification::topLeft);
+                g.setFont(juce::Font(16.0, juce::Font::plain));
+                g.drawText(title, 8, 4, 200, 200, juce::Justification::topLeft);
             }
         }
 
         // ------------------------------------------------------------------------
 
 protected:
-        OwnedArray<Label> labels;
-        OwnedArray<TextButton> textButtons;
-        OwnedArray<ToggleButton> toggleButtons;
-        OwnedArray<ComboBox> comboBoxes;
+        juce::OwnedArray<juce::Label> labels;
+        juce::OwnedArray<juce::TextButton> textButtons;
+        juce::OwnedArray<juce::ToggleButton> toggleButtons;
+        juce::OwnedArray<juce::ComboBox> comboBoxes;
 
         // ------------------------------------------------------------------------
 
-        int addLabel(Point<int>& topLeft, const String text, const LabelStyle style)
+        int addLabel(juce::Point<int>& topLeft, const juce::String text, const LabelStyle style)
         {
             int styleIndex;
             switch (style)
@@ -121,16 +121,16 @@ protected:
             }
 
             const float LabelFontSize[4] = { 15.5f, 14.5f, 16.0f, 16.0f };
-            const int LabelFontStyle[4] = { Font::FontStyleFlags::bold, 0, 0, 0 };
-            const Colour LabelColour[4] = { SectionLabel, Colour(0xff808186), Colour(0xffd8d8d8), Colour(0xffa4a5a8)};
+            const int LabelFontStyle[4] = { juce::Font::FontStyleFlags::bold, 0, 0, 0 };
+            const juce::Colour LabelColour[4] = { SectionLabel, juce::Colour(0xff808186), juce::Colour(0xffd8d8d8), juce::Colour(0xffa4a5a8)};
             const int LineHeight[4] = { 28, 24, 24, 24 };
 
             int index = labels.size();
-            Label* lb = labels.add(new Label(text, text));
+            juce::Label* lb = labels.add(new juce::Label(text, text));
             lb->setTopLeftPosition(topLeft);
             lb->setSize(LabelWidth, LineHeight[styleIndex]);
-            lb->setFont(Font(LabelFontSize[styleIndex], LabelFontStyle[styleIndex]));
-            lb->setColour(Label::ColourIds::textColourId, LabelColour[styleIndex]);
+            lb->setFont(juce::Font(LabelFontSize[styleIndex], LabelFontStyle[styleIndex]));
+            lb->setColour(juce::Label::ColourIds::textColourId, LabelColour[styleIndex]);
             topLeft.y += LineHeight[styleIndex] + 3;
             addAndMakeVisible(lb);
             return index;
@@ -138,11 +138,11 @@ protected:
 
         // ------------------------------------------------------------------------
 
-        int addTextButton(Point<int>& topLeft, const String text, const int width)
+        int addTextButton(juce::Point<int>& topLeft, const juce::String text, const int width)
         {
             constexpr int ButtonHeight { 24 };
             int index = textButtons.size();
-            TextButton* tb = textButtons.add(new TextButton(text));
+            juce::TextButton* tb = textButtons.add(new juce::TextButton(text));
             tb->setTopLeftPosition(topLeft.translated(Indent + 10, 2));
             tb->setSize(width, ButtonHeight);
             tb->addListener(this);
@@ -153,14 +153,14 @@ protected:
 
         // ------------------------------------------------------------------------
 
-        int addToggle(Point<int>& topLeft, const String text, const int radioGroupID = -1)
+        int addToggle(juce::Point<int>& topLeft, const juce::String text, const int radioGroupID = -1)
         {
             constexpr int ToggleHeight { 22 };
             int index = toggleButtons.size();
-            ToggleButton* tb = toggleButtons.add(new ToggleButton(text));
+            juce::ToggleButton* tb = toggleButtons.add(new juce::ToggleButton(text));
             if (radioGroupID >= 0)
             {
-                tb->setRadioGroupId(radioGroupID, dontSendNotification);
+                tb->setRadioGroupId(radioGroupID, juce::dontSendNotification);
                 tb->setLookAndFeel(&lookAndFeelRadio);
             }
             tb->setTopLeftPosition(topLeft.translated(Indent, 0));
@@ -173,11 +173,11 @@ protected:
 
         // ------------------------------------------------------------------------
 
-        int addComboBox(Point<int>& topLeft, const StringArray& text)
+        int addComboBox(juce::Point<int>& topLeft, const juce::StringArray& text)
         {
             constexpr int ComboBoxHeight { 24 };
             int index = comboBoxes.size();
-            ComboBox* cb = comboBoxes.add(new ComboBox());
+            juce::ComboBox* cb = comboBoxes.add(new juce::ComboBox());
             cb->setEditableText(false);
             cb->addItemList(text, 1);
             cb->setTopLeftPosition(topLeft.translated(Indent - 4, 0));
@@ -202,9 +202,9 @@ protected:
         // ------------------------------------------------------------------------
 
     protected:
-        String title;
-        const Colour TitleLabel = Colour(0xff28789c);
-        const Colour SectionLabel = Colour(0xff529aca);
+        juce::String title;
+        const juce::Colour TitleLabel = juce::Colour(0xff28789c);
+        const juce::Colour SectionLabel = juce::Colour(0xff529aca);
 
         static constexpr int Indent { 18 };
 

--- a/supperware/configpanel/configPanel-LookAndFeelRadio.h
+++ b/supperware/configpanel/configPanel-LookAndFeelRadio.h
@@ -8,28 +8,28 @@
 
 namespace ConfigPanel
 {
-    class LookAndFeelRadio : public LookAndFeel_V4
+    class LookAndFeelRadio : public juce::LookAndFeel_V4
     {
     public:
         ~LookAndFeelRadio() override {}
 
-        void drawTickBox (Graphics& g, Component& component,
+        void drawTickBox (juce::Graphics& g, juce::Component& component,
                           float x, float y, float w, float h,
                           const bool ticked,
                           const bool isEnabled,
                           const bool shouldDrawButtonAsHighlighted,
                           const bool shouldDrawButtonAsDown) override
         {
-            ignoreUnused (isEnabled, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+            juce::ignoreUnused (isEnabled, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
 
-            Rectangle<float> tickBounds (x, y, w, h);
+            juce::Rectangle<float> tickBounds (x, y, w, h);
 
-            g.setColour (component.findColour (ToggleButton::tickDisabledColourId));
+            g.setColour (component.findColour (juce::ToggleButton::tickDisabledColourId));
             g.drawEllipse (tickBounds.reduced(0.5f, 0.5f), 1.0f);
     
             if (ticked)
             {
-                g.setColour (component.findColour (ToggleButton::tickColourId));
+                g.setColour (component.findColour (juce::ToggleButton::tickColourId));
                 g.fillEllipse(tickBounds.reduced (5.5f, 5.5f).toFloat());
             }
         }

--- a/supperware/configpanel/configPanel-SettingsPanel.h
+++ b/supperware/configpanel/configPanel-SettingsPanel.h
@@ -14,7 +14,7 @@ namespace ConfigPanel
             BasePanel(""),
             td(trackerDriver)
         {
-            Point<int> position(4, yOrigin());
+            juce::Point<int> position(4, yOrigin());
             addLabel(position, "Chirality", LabelStyle::SectionHeading);
             addToggle(position, "Cable on left", 1);
             addToggle(position, "Cable on right", 1);
@@ -24,7 +24,7 @@ namespace ConfigPanel
             addToggle(position, "Slow central pull", 2);
 
             position.addXY(0,2);
-            Point<int> rightPos = position;
+            juce::Point<int> rightPos = position;
             rightPos.addXY(132, 26);
             addTextButton(position, "Calibrate compass", 172);
             addLabel(rightPos, "", LabelStyle::SubData);
@@ -77,7 +77,7 @@ namespace ConfigPanel
             if (timerID == 1)
             {
                 setCompassLabel();
-                MultiTimer::stopTimer(timerID);
+                juce::MultiTimer::stopTimer(timerID);
             }
             BasePanel::timerCallback(timerID);
         }
@@ -113,20 +113,20 @@ namespace ConfigPanel
 
         void trackUpdatedState(bool rightEarChirality, bool compassOn, Tracker::TravelMode travelMode)
         {
-            MessageManagerLock mml;
+            juce::MessageManagerLock mml;
             bool isConnected = td.isConnected();
             setEnabled(isConnected);
             if(isConnected)
             {
-                toggleButtons[0]->setToggleState(!rightEarChirality, dontSendNotification);
-                toggleButtons[1]->setToggleState(rightEarChirality, dontSendNotification);
+                toggleButtons[0]->setToggleState(!rightEarChirality, juce::dontSendNotification);
+                toggleButtons[1]->setToggleState(rightEarChirality, juce::dontSendNotification);
                 //
-                toggleButtons[2]->setToggleState(compassOn, dontSendNotification);
-                toggleButtons[3]->setToggleState(!compassOn, dontSendNotification);
+                toggleButtons[2]->setToggleState(compassOn, juce::dontSendNotification);
+                toggleButtons[3]->setToggleState(!compassOn, juce::dontSendNotification);
                 //
-                toggleButtons[4]->setToggleState(travelMode == Tracker::TravelMode::Off, dontSendNotification);
-                toggleButtons[5]->setToggleState(travelMode == Tracker::TravelMode::Slow, dontSendNotification);
-                toggleButtons[6]->setToggleState(travelMode == Tracker::TravelMode::Fast, dontSendNotification);
+                toggleButtons[4]->setToggleState(travelMode == Tracker::TravelMode::Off, juce::dontSendNotification);
+                toggleButtons[5]->setToggleState(travelMode == Tracker::TravelMode::Slow, juce::dontSendNotification);
+                toggleButtons[6]->setToggleState(travelMode == Tracker::TravelMode::Fast, juce::dontSendNotification);
             }
             flagRepaint();
         }
@@ -141,8 +141,8 @@ namespace ConfigPanel
 
         void setCompassLabel()
         {
-            MessageManagerLock mml; // needed for setEnabled
-            String labelText = "";
+            juce::MessageManagerLock mml; // needed for setEnabled
+            juce::String labelText = "";
             if (td.isConnected())
             {
                 if (compassState == Tracker::CompassState::Calibrating)    labelText = "CALIBRATING";
@@ -151,7 +151,7 @@ namespace ConfigPanel
                 else if (compassState == Tracker::CompassState::GoodData)  labelText = "GOOD DATA";
                 else if (compassState == Tracker::CompassState::BadData)   labelText = "BAD DATA";
             }
-            labels[2]->setText(labelText, dontSendNotification);
+            labels[2]->setText(labelText, juce::dontSendNotification);
             textButtons[0]->setEnabled(compassState != Tracker::CompassState::Calibrating);
         }
     };

--- a/supperware/headpanel/headpanel-Component.h
+++ b/supperware/headpanel/headpanel-Component.h
@@ -11,7 +11,7 @@ namespace HeadPanel
     /** Component that manages head tracker settings, disconnection/reconnection, and shows 
       * instantaneous head angle. Also owns Midi::Tracker and SBR::HeadMatrix objects, which
       * are useful everywhere else. */
-    class HeadPanel: public Component, Timer, Midi::TrackerDriver::Listener, HeadButton::Listener
+    class HeadPanel: public juce::Component, juce::Timer, Midi::TrackerDriver::Listener, HeadButton::Listener
 
     {
     public:
@@ -33,8 +33,8 @@ namespace HeadPanel
             doRepaint(false),
             midiState(Midi::State::Unavailable)
         {
-            MemoryInputStream mis(BinaryData::mini_tile_png, BinaryData::mini_tile_pngSize, false);
-            Image im = ImageFileFormat::loadFrom(mis);
+            juce::MemoryInputStream mis(BinaryData::mini_tile_png, BinaryData::mini_tile_pngSize, false);
+            juce::Image im = juce::ImageFileFormat::loadFrom(mis);
 
             setSize(148, 104);
             doButton(hbConfigure, im, 0, 2, 6);
@@ -58,7 +58,7 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void paint(Graphics& g) override
+        void paint(juce::Graphics& g) override
         {
             //g.setColour(Colour(0xff404040));
             //g.drawRect(g.getClipBounds(), 1.0f);
@@ -131,7 +131,7 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void mouseDoubleClick(const MouseEvent& /*event*/) override
+        void mouseDoubleClick(const juce::MouseEvent& /*event*/) override
         {
             trackerDriver.zero();
         }
@@ -143,9 +143,9 @@ namespace HeadPanel
             if (!index)
             {
                 // settings button
-                DialogWindow::LaunchOptions lo;
+                juce::DialogWindow::LaunchOptions lo;
                 lo.content.set(&settingsPanel, false);
-                lo.dialogBackgroundColour = Colour(0xff181818);
+                lo.dialogBackgroundColour = juce::Colour(0xff181818);
                 lo.dialogTitle = "Head Tracker Settings";
                 lo.escapeKeyTriggersCloseButton = true;
                 lo.resizable = false;
@@ -170,17 +170,17 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void doButton(HeadButton& b, Image& masterImage, int imageIndex, int x, int y)
+        void doButton(HeadButton& b, juce::Image& masterImage, int imageIndex, int x, int y)
         {
             double dpi = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->dpi;
-            Image subImage;
+            juce::Image subImage;
             if (dpi > 128.0)
             {
-                subImage = masterImage.getClippedImage(Rectangle<int>(40 + 120 * imageIndex, 0, 120, 120));
+                subImage = masterImage.getClippedImage(juce::Rectangle<int>(40 + 120 * imageIndex, 0, 120, 120));
             }
             else
             {
-                subImage = masterImage.getClippedImage(Rectangle<int>(0, 40 * imageIndex, 40, 40));
+                subImage = masterImage.getClippedImage(juce::Rectangle<int>(0, 40 * imageIndex, 40, 40));
             }
 
             b.setTopLeftPosition(x, y);
@@ -195,7 +195,7 @@ namespace HeadPanel
             stopTimer();
             if (doRepaint)
             {
-                MessageManagerLock mml;
+                juce::MessageManagerLock mml;
                 doRepaint = false;
                 repaint();
             }

--- a/supperware/headpanel/headpanel-HeadButton.h
+++ b/supperware/headpanel/headpanel-HeadButton.h
@@ -8,7 +8,7 @@
 
 namespace HeadPanel
 {
-    class HeadButton: public Component, private Timer
+    class HeadButton: public juce::Component, private juce::Timer
     {
     public:
         class Listener
@@ -24,22 +24,22 @@ namespace HeadPanel
             setSize(40, 40);
         }
 
-        void paint(Graphics& g) override
+        void paint(juce::Graphics& g) override
         {
             if (isHovering && !isSelected)
             {
-                g.setColour(Colour(0x20ffffff));
+                g.setColour(juce::Colour(0x20ffffff));
                 g.fillRect(g.getClipBounds());
             }
-            /**/ if (isSelected) { g.setColour(Colours::white); }
-            else if (isHovering) { g.setColour(Colour(0x80ffffff)); }
-            else                 { g.setColour(Colour(0x40ffffff)); }
-            g.drawImageWithin(im, 0, 0, 40, 40, RectanglePlacement());
+            /**/ if (isSelected) { g.setColour(juce::Colours::white); }
+            else if (isHovering) { g.setColour(juce::Colour(0x80ffffff)); }
+            else                 { g.setColour(juce::Colour(0x40ffffff)); }
+            g.drawImageWithin(im, 0, 0, 40, 40, juce::RectanglePlacement());
         }
 
         //----------------------------------------------------------------------
 
-        void mouseEnter(const MouseEvent& /*event*/) override
+        void mouseEnter(const juce::MouseEvent& /*event*/) override
         {
             isHovering = true;
             flagRepaint();
@@ -47,7 +47,7 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void mouseExit(const MouseEvent& /*event*/) override
+        void mouseExit(const juce::MouseEvent& /*event*/) override
         {
             isHovering = false;
             flagRepaint();
@@ -55,7 +55,7 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void mouseUp(const MouseEvent& /*event*/) override
+        void mouseUp(const juce::MouseEvent& /*event*/) override
         {
             isHovering = false;
             flagRepaint();
@@ -63,14 +63,14 @@ namespace HeadPanel
 
         //----------------------------------------------------------------------
 
-        void mouseDown(const MouseEvent& /*event*/) override
+        void mouseDown(const juce::MouseEvent& /*event*/) override
         {
             l->headButtonSelect(listenerIndex);
         }
 
         //----------------------------------------------------------------------
 
-        void setImage(const Image& image)
+        void setImage(const juce::Image& image)
         {
             im = image;
             im.duplicateIfShared();
@@ -98,7 +98,7 @@ namespace HeadPanel
             stopTimer();
             if (doRepaint)
             {
-                MessageManagerLock mml;
+                juce::MessageManagerLock mml;
                 doRepaint = false;
                 repaint();
             }
@@ -108,7 +108,7 @@ namespace HeadPanel
 
     private:
         Listener* l;
-        Image im;
+        juce::Image im;
         int listenerIndex;
         bool isSelected, isHovering, doRepaint;
 

--- a/supperware/headpanel/headpanel-Plotter.h
+++ b/supperware/headpanel/headpanel-Plotter.h
@@ -22,7 +22,7 @@ namespace HeadPanel
         /** Rotates head appropriately to a new position */
         void recalculate(const HeadMatrix& headMatrix)
         {
-            ScopedLock sl(calculateOrPaint);
+            juce::ScopedLock sl(calculateOrPaint);
             pointList.clear();
             uint8_t i;
 
@@ -74,27 +74,27 @@ namespace HeadPanel
 
         // --------------------------------------------------------------------
 
-        void paint(Graphics& g, const float xMid, const float yMid,
+        void paint(juce::Graphics& g, const float xMid, const float yMid,
             const float scale, const float lineThickness, const Midi::State connectionState) const
         {
-            Rectangle<float> bounds(xMid - scale, yMid - scale, 2.0f * scale, 2.0f * scale);
+            juce::Rectangle<float> bounds(xMid - scale, yMid - scale, 2.0f * scale, 2.0f * scale);
 
             if (connectionState == Midi::State::Bootloader)
             {
                 g.setFont(juce::Font (15.0f));
-                g.setColour(Colour(0xff808080));
-                g.drawText("BOOTLOADER", bounds, Justification::centred);
+                g.setColour(juce::Colour(0xff808080));
+                g.drawText("BOOTLOADER", bounds, juce::Justification::centred);
             }
             else if (connectionState == Midi::State::Connected)
             {
-                ScopedLock sl(calculateOrPaint);
-                g.setColour(Colours::black);
+                juce::ScopedLock sl(calculateOrPaint);
+                g.setColour(juce::Colours::black);
                 g.fillEllipse(xMid - scale, yMid - (scale * sinGaze), scale * 2.0f, scale * sinGaze * 2.0f);
                 pointList.paint(g, static_cast<int>(xMid), static_cast<int>(yMid), scale, lineThickness);
             }
             else
             {
-                g.setColour(Colour(0xff282828));
+                g.setColour(juce::Colour(0xff282828));
                 g.drawEllipse(bounds, lineThickness);
             }
         }
@@ -105,7 +105,7 @@ namespace HeadPanel
         void setGazeAngle(const float gazeDegrees)
         {
             // 0 to 90
-            float gazeRadians = gazeDegrees * MathConstants<float>::pi / 180.0f;
+            float gazeRadians = gazeDegrees * juce::MathConstants<float>::pi / 180.0f;
             sinGaze = sinf(gazeRadians);
             cosGaze = cosf(gazeRadians);
         }
@@ -114,20 +114,20 @@ namespace HeadPanel
 
     private:
         static constexpr int Heatmap_Count = 18;
-        const Colour DefaultHeatmap[Heatmap_Count] = {
-            Colour(0x88580818), Colour(0xcc580818), Colour(0xf0580818),
-            Colour(0xff800820), Colour(0xffa01030), Colour(0xffc0183c),
-            Colour(0xffd0284a), Colour(0xffd8345c), Colour(0xffe04c6a),
-            Colour(0xffec5878), Colour(0xfff46484), Colour(0xfff87890),
-            Colour(0xfffc88a0), Colour(0xffff98ac), Colour(0xffffa0bc),
-            Colour(0xffffacc8), Colour(0xffffbcd8), Colour(0xffffd0ec)
+        const juce::Colour DefaultHeatmap[Heatmap_Count] = {
+            juce::Colour(0x88580818), juce::Colour(0xcc580818), juce::Colour(0xf0580818),
+            juce::Colour(0xff800820), juce::Colour(0xffa01030), juce::Colour(0xffc0183c),
+            juce::Colour(0xffd0284a), juce::Colour(0xffd8345c), juce::Colour(0xffe04c6a),
+            juce::Colour(0xffec5878), juce::Colour(0xfff46484), juce::Colour(0xfff87890),
+            juce::Colour(0xfffc88a0), juce::Colour(0xffff98ac), juce::Colour(0xffffa0bc),
+            juce::Colour(0xffffacc8), juce::Colour(0xffffbcd8), juce::Colour(0xffffd0ec)
         };
 
         // --------------------------------------------------------------------
 
         PointList pointList;
         float cosGaze, sinGaze;
-        CriticalSection calculateOrPaint;
+        juce::CriticalSection calculateOrPaint;
 
         // --------------------------------------------------------------------
         //                                                        3D PROJECTION
@@ -136,7 +136,7 @@ namespace HeadPanel
         void project3D(const V3 v, const HeadMatrix& headMatrix,
             const bool flipX, const bool closeLine)
         {
-            Vector3D<float> t(flipX ? v[0] : -v[0], v[1], v[2]);
+            juce::Vector3D<float> t(flipX ? v[0] : -v[0], v[1], v[2]);
             headMatrix.transform(t.x, t.y, t.z);
 
             float ty  = cosGaze * t.y - sinGaze * t.z;
@@ -144,7 +144,7 @@ namespace HeadPanel
             t.y = ty;
 
             int tempInten = static_cast<int>(8.8f * (1.0f - ty));
-            Colour c = (tempInten < 0) ? DefaultHeatmap[0] :
+            juce::Colour c = (tempInten < 0) ? DefaultHeatmap[0] :
                        (tempInten >= Heatmap_Count) ? DefaultHeatmap[Heatmap_Count - 1] :
                         DefaultHeatmap[tempInten];
 

--- a/supperware/headpanel/headpanel-PointList.h
+++ b/supperware/headpanel/headpanel-PointList.h
@@ -14,7 +14,7 @@ namespace HeadPanel
         
         struct PointItem
         {
-            PointItem(float _x, float _y, float _z, Colour _colour, bool _closeLine):
+            PointItem(float _x, float _y, float _z, juce::Colour _colour, bool _closeLine):
                 x(_x),
                 y(_y),
                 z(_z),
@@ -25,7 +25,7 @@ namespace HeadPanel
             {}
 
             float x, y, z;
-            Colour colour;
+            juce::Colour colour;
             signed int linkForwards, linkBackwards;
             bool closeLine;
         };
@@ -49,7 +49,7 @@ namespace HeadPanel
 
         // ------------------------------------------------------------------------
 
-        void addPoint(const float x, const float y, float z, const Colour colour, const bool closeLine)
+        void addPoint(const float x, const float y, float z, const juce::Colour colour, const bool closeLine)
         {
             points.push_back(PointItem(x, y, z, colour, closeLine));
             PointItem* p = &points[points.size() - 1];
@@ -77,7 +77,7 @@ namespace HeadPanel
 
         // ------------------------------------------------------------------------
 
-        void paint(Graphics& g, const int xMid, const int yMid, const float scale, const float lineThickness) const
+        void paint(juce::Graphics& g, const int xMid, const int yMid, const float scale, const float lineThickness) const
         {
             int index = rearItem;
             while (index != -1)

--- a/supperware/midi/midi-MidiDuplex.h
+++ b/supperware/midi/midi-MidiDuplex.h
@@ -12,10 +12,10 @@ namespace Midi
     enum class State { Unavailable, Available, Bootloader, Connected };
     enum class Connection { AsBootloader, AsDevice, AsEither };
 
-    class MidiDuplex : public MidiInputCallback, protected Timer
+    class MidiDuplex : public juce::MidiInputCallback, protected juce::Timer
     {
     public:
-        MidiDuplex(const String deviceName, const String bootloaderName) :
+        MidiDuplex(const juce::String deviceName, const juce::String bootloaderName) :
             midiOut(nullptr),
             midiIn(nullptr),
             device(deviceName),
@@ -106,8 +106,8 @@ namespace Midi
             
             if ((outputIndex >= 0) && (inputIndex >= 0))
             {
-                midiOut = MidiOutput::openDevice(outputIndex);
-                midiIn  = MidiInput::openDevice(inputIndex, this);
+                midiOut = juce::MidiOutput::openDevice(outputIndex);
+                midiIn  = juce::MidiInput::openDevice(inputIndex, this);
                 if (midiOut && midiIn)
                 {
                     midiIn->start();
@@ -137,7 +137,7 @@ namespace Midi
 
         // ------------------------------------------------------------------------
 
-        void sendMessage(const MidiMessage& message)
+        void sendMessage(const juce::MidiMessage& message)
         {
             if (midiOut)
             {
@@ -147,7 +147,7 @@ namespace Midi
 
         // ------------------------------------------------------------------------
 
-        void handleIncomingMidiMessage(MidiInput* /*source*/, const MidiMessage& message)
+        void handleIncomingMidiMessage(juce::MidiInput* /*source*/, const juce::MidiMessage& message)
         {
             if (autoDisconnect)
             {
@@ -201,16 +201,16 @@ namespace Midi
         // ------------------------------------------------------------------------
 
     protected:
-        std::unique_ptr<MidiOutput> midiOut;
-        std::unique_ptr<MidiInput> midiIn;
-        String device, bootloader;
+        std::unique_ptr<juce::MidiOutput> midiOut;
+        std::unique_ptr<juce::MidiInput> midiIn;
+        juce::String device, bootloader;
         State connectionState;
         bool autoReconnect, autoDisconnect;
 
         // ------------------------------------------------------------------------
 
-        virtual void handleSysEx(const uint8* /*buffer*/, const size_t /*numBytes*/) {}
-        virtual void handleMidi(const MidiMessage& /*message*/) {}
+        virtual void handleSysEx(const uint8_t* /*buffer*/, const size_t /*numBytes*/) {}
+        virtual void handleMidi(const juce::MidiMessage& /*message*/) {}
         virtual void connectionStateChanged() {}
         
         // ------------------------------------------------------------------------
@@ -228,9 +228,9 @@ namespace Midi
         
         void getIndexes(bool& wouldConnectToBootloader, int& outputIndex, int& inputIndex) const
         {
-            StringArray sa;
+            juce::StringArray sa;
             int index;
-            sa = MidiOutput::getDevices();
+            sa = juce::MidiOutput::getDevices();
             index = sa.indexOf(device);
             if (index >= 0)
             {
@@ -253,7 +253,7 @@ namespace Midi
 
             if (outputIndex >= 0)
             {
-                sa = MidiInput::getDevices();
+                sa = juce::MidiInput::getDevices();
                 if (wouldConnectToBootloader)
                 {
                     inputIndex = sa.indexOf(bootloader);

--- a/supperware/midi/midi-TrackerDriver.h
+++ b/supperware/midi/midi-TrackerDriver.h
@@ -66,7 +66,7 @@ namespace Midi
             {
                 isTrackerOn = false;
                 size_t numBytes = tracker.turnOffMessage(midiBuffer);
-                sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+                sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
             }
         }
 
@@ -86,7 +86,7 @@ namespace Midi
                 isQuaternion = isQuaternionMode;
                 isTrackerOn = true;
                 size_t numBytes = tracker.turnOnMessage(midiBuffer, isQuaternion, is100Hz);
-                sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+                sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
             }
         }
 
@@ -96,7 +96,7 @@ namespace Midi
         void zero()
         {
             size_t numBytes = tracker.zeroMessage(midiBuffer);
-            sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+            sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
         }
 
         // ------------------------------------------------------------------------
@@ -105,7 +105,7 @@ namespace Midi
         void setChirality(const bool isRightEarChirality)
         {
             size_t numBytes = tracker.chiralityMessage(midiBuffer, isRightEarChirality);
-            sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+            sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
         }
         
         // ------------------------------------------------------------------------
@@ -114,7 +114,7 @@ namespace Midi
         void setTravelMode(const Tracker::TravelMode newTravelMode)
         {
             size_t numBytes = tracker.travelModeMessage(midiBuffer, newTravelMode);
-            sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+            sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
         }
 
         // ------------------------------------------------------------------------
@@ -124,7 +124,7 @@ namespace Midi
         void setCompass(bool compassShouldBeOn)
         {
             size_t numBytes = tracker.compassMessage(midiBuffer, compassShouldBeOn);
-            sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+            sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
         }
         
         // ------------------------------------------------------------------------
@@ -133,13 +133,13 @@ namespace Midi
         void calibrateCompass()
         {
             size_t numBytes = tracker.calibrateCompassMessage(midiBuffer);
-            sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+            sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
         }
 
         // ------------------------------------------------------------------------
 
     protected:
-        virtual void handleOtherSysEx(const uint8* /*buffer*/, const size_t /*numBytes*/) {}
+        virtual void handleOtherSysEx(const uint8_t* /*buffer*/, const size_t /*numBytes*/) {}
 
         // ------------------------------------------------------------------------
 
@@ -160,10 +160,10 @@ namespace Midi
                 if (isTrackerOn)
                 {
                     size_t numBytes = tracker.turnOnMessage(midiBuffer, isQuaternion, is100Hz);
-                    sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+                    sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
                 }
                 size_t numBytes = tracker.readbackMessage(midiBuffer);
-                sendMessage(MidiMessage(midiBuffer, (int)numBytes));
+                sendMessage(juce::MidiMessage(midiBuffer, (int)numBytes));
             }
             l->trackerMidiConnectionChanged(connectionState);
         }
@@ -173,7 +173,7 @@ namespace Midi
     private:
         Listener* l;
         Tracker tracker;
-        Vector3D<float> position;
+        juce::Vector3D<float> position;
         uint8_t midiBuffer[16];
         bool isQuaternion;
         bool is100Hz;


### PR DESCRIPTION
removed the `using namespace juce;` declaration to make it more flexible with other projects when used as a submodule