### PR TITLE
Compare only start of MIDI device names with given string

### DIFF
--- a/supperware/midi/midi-MidiDuplex.h
+++ b/supperware/midi/midi-MidiDuplex.h
@@ -233,7 +233,7 @@ namespace Midi
         {
             const int size = mdInfo.size();
             int index = 0;
-            while ((index < size) && (mdInfo[index].name != deviceName))
+            while ((index < size) && !(mdInfo[index].name.startsWith(deviceName)))
             {
                 index++;
             }


### PR DESCRIPTION
The device name "Head Tracker" is hard-coded in the API:

https://github.com/Supperware/ht-api-juce/blob/bd6dbdd62d2eb26ccd3a6c589d51fd8aefc73c45/supperware/midi/midi-TrackerDriver.h#L32

If the OS decides to rename the MIDI device name (e.g. to "Head Tracker MIDI 1" on my Linux distribution, or when using multiple head trackers), the device is never set available, as the names don't match. This can be avoided by just comparing the start of the device names with the given string.
